### PR TITLE
Integrate remote cluster state in publish flow

### DIFF
--- a/server/src/main/java/org/opensearch/cluster/coordination/CoordinationState.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/CoordinationState.java
@@ -503,7 +503,7 @@ public class CoordinationState {
                 publishResponse.getVersion(),
                 publishResponse.getTerm()
             );
-            handleRemoteCommit();
+            handlePreCommit();
             return Optional.of(new ApplyCommitRequest(localNode, publishResponse.getTerm(), publishResponse.getVersion()));
         }
 
@@ -565,14 +565,16 @@ public class CoordinationState {
         assert getLastCommittedConfiguration().equals(getLastAcceptedConfiguration());
     }
 
-    public void handleRemotePublish(ClusterState clusterState) {
+    public void handlePrePublish(ClusterState clusterState) {
+        // Publishing the current state to remote store
         if (isRemoteStateEnabled == true) {
             assert remotePersistedState != null : "Remote state has not been initialized";
             remotePersistedState.setLastAcceptedState(clusterState);
         }
     }
 
-    public void handleRemoteCommit() {
+    public void handlePreCommit() {
+        // Publishing the committed state to remote store before sending apply commit to other nodes.
         if (isRemoteStateEnabled) {
             assert remotePersistedState != null : "Remote state has not been initialized";
             remotePersistedState.markLastAcceptedStateAsCommitted();

--- a/server/src/main/java/org/opensearch/cluster/coordination/CoordinationState.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/CoordinationState.java
@@ -37,6 +37,7 @@ import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.coordination.CoordinationMetadata.VotingConfiguration;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.common.settings.Settings;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -49,6 +50,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static org.opensearch.cluster.coordination.Coordinator.ZEN1_BWC_TERM;
+import static org.opensearch.gateway.remote.RemoteClusterStateService.REMOTE_CLUSTER_STATE_ENABLED_SETTING;
 
 /**
  * The core class of the cluster state coordination algorithm, directly implementing the
@@ -66,6 +68,8 @@ public class CoordinationState {
 
     // persisted state
     private final PersistedState persistedState;
+    // remote persisted state
+    private final PersistedState remotePersistedState;
 
     // transient state
     private VoteCollection joinVotes;
@@ -74,8 +78,15 @@ public class CoordinationState {
     private long lastPublishedVersion;
     private VotingConfiguration lastPublishedConfiguration;
     private VoteCollection publishVotes;
+    private boolean isRemoteStateEnabled;
 
-    public CoordinationState(DiscoveryNode localNode, PersistedState persistedState, ElectionStrategy electionStrategy) {
+    public CoordinationState(
+        DiscoveryNode localNode,
+        PersistedState persistedState,
+        ElectionStrategy electionStrategy,
+        PersistedState remotePersistedState,
+        Settings settings
+    ) {
         this.localNode = localNode;
 
         // persisted state
@@ -89,6 +100,8 @@ public class CoordinationState {
         this.lastPublishedVersion = 0L;
         this.lastPublishedConfiguration = persistedState.getLastAcceptedState().getLastAcceptedConfiguration();
         this.publishVotes = new VoteCollection();
+        this.remotePersistedState = remotePersistedState;
+        this.isRemoteStateEnabled = REMOTE_CLUSTER_STATE_ENABLED_SETTING.get(settings);
     }
 
     public long getCurrentTerm() {
@@ -490,6 +503,7 @@ public class CoordinationState {
                 publishResponse.getVersion(),
                 publishResponse.getTerm()
             );
+            handleRemoteCommit();
             return Optional.of(new ApplyCommitRequest(localNode, publishResponse.getTerm(), publishResponse.getVersion()));
         }
 
@@ -549,6 +563,20 @@ public class CoordinationState {
 
         persistedState.markLastAcceptedStateAsCommitted();
         assert getLastCommittedConfiguration().equals(getLastAcceptedConfiguration());
+    }
+
+    public void handleRemotePublish(ClusterState clusterState) {
+        if (isRemoteStateEnabled == true) {
+            assert remotePersistedState != null : "Remote state has not been initialized";
+            remotePersistedState.setLastAcceptedState(clusterState);
+        }
+    }
+
+    public void handleRemoteCommit() {
+        if (isRemoteStateEnabled) {
+            assert remotePersistedState != null : "Remote state has not been initialized";
+            remotePersistedState.markLastAcceptedStateAsCommitted();
+        }
     }
 
     public void invariant() {

--- a/server/src/main/java/org/opensearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/Coordinator.java
@@ -182,6 +182,7 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
     private JoinHelper.JoinAccumulator joinAccumulator;
     private Optional<CoordinatorPublication> currentPublication = Optional.empty();
     private final NodeHealthService nodeHealthService;
+    private final PersistedStateRegistry persistedStateRegistry;
 
     /**
      * @param nodeName The name of the node, used to name the {@link java.util.concurrent.ExecutorService} of the {@link SeedHostsResolver}.
@@ -202,7 +203,8 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
         Random random,
         RerouteService rerouteService,
         ElectionStrategy electionStrategy,
-        NodeHealthService nodeHealthService
+        NodeHealthService nodeHealthService,
+        PersistedStateRegistry persistedStateRegistry
     ) {
         this.settings = settings;
         this.transportService = transportService;
@@ -287,6 +289,7 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
             joinHelper::logLastFailedJoinAttempt
         );
         this.nodeHealthService = nodeHealthService;
+        this.persistedStateRegistry = persistedStateRegistry;
         this.localNodeCommissioned = true;
     }
 
@@ -827,7 +830,7 @@ public class Coordinator extends AbstractLifecycleComponent implements Discovery
                     getLocalNode(),
                     persistedState,
                     electionStrategy,
-                    PersistedStateRegistry.getPersistedState(PersistedStateType.REMOTE),
+                    persistedStateRegistry.getPersistedState(PersistedStateType.REMOTE),
                     settings
                 )
             );

--- a/server/src/main/java/org/opensearch/cluster/coordination/PersistedStateRegistry.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/PersistedStateRegistry.java
@@ -10,19 +10,19 @@ package org.opensearch.cluster.coordination;
 
 import org.opensearch.cluster.coordination.CoordinationState.PersistedState;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * A class which encapsulates the PersistedStates
  *
  * @opensearch.internal
  */
-public class PersistentStateRegistry {
+public class PersistedStateRegistry {
 
-    private static final PersistentStateRegistry INSTANCE = new PersistentStateRegistry();
+    private static final PersistedStateRegistry INSTANCE = new PersistedStateRegistry();
 
-    private PersistentStateRegistry() {}
+    private PersistedStateRegistry() {}
 
     /**
      * Distinct Types PersistedState which can be present on a node
@@ -32,15 +32,15 @@ public class PersistentStateRegistry {
         REMOTE
     }
 
-    private final Map<PersistedStateType, PersistedState> persistentStates = new HashMap<>();
+    private final Map<PersistedStateType, PersistedState> persistedStates = new ConcurrentHashMap<>();
 
     public static void addPersistedState(PersistedStateType persistedStateType, PersistedState persistedState) {
-        PersistedState existingState = INSTANCE.persistentStates.putIfAbsent(persistedStateType, persistedState);
+        PersistedState existingState = INSTANCE.persistedStates.putIfAbsent(persistedStateType, persistedState);
         assert existingState == null : "should only be set once, but already have " + existingState;
     }
 
     public static PersistedState getPersistedState(PersistedStateType persistedStateType) {
-        return INSTANCE.persistentStates.get(persistedStateType);
+        return INSTANCE.persistedStates.get(persistedStateType);
     }
 
 }

--- a/server/src/main/java/org/opensearch/cluster/coordination/PersistedStateRegistry.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/PersistedStateRegistry.java
@@ -20,9 +20,7 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class PersistedStateRegistry {
 
-    private static final PersistedStateRegistry INSTANCE = new PersistedStateRegistry();
-
-    private PersistedStateRegistry() {}
+    public PersistedStateRegistry() {}
 
     /**
      * Distinct Types PersistedState which can be present on a node
@@ -34,13 +32,13 @@ public class PersistedStateRegistry {
 
     private final Map<PersistedStateType, PersistedState> persistedStates = new ConcurrentHashMap<>();
 
-    public static void addPersistedState(PersistedStateType persistedStateType, PersistedState persistedState) {
-        PersistedState existingState = INSTANCE.persistedStates.putIfAbsent(persistedStateType, persistedState);
+    public void addPersistedState(PersistedStateType persistedStateType, PersistedState persistedState) {
+        PersistedState existingState = this.persistedStates.putIfAbsent(persistedStateType, persistedState);
         assert existingState == null : "should only be set once, but already have " + existingState;
     }
 
-    public static PersistedState getPersistedState(PersistedStateType persistedStateType) {
-        return INSTANCE.persistedStates.get(persistedStateType);
+    public PersistedState getPersistedState(PersistedStateType persistedStateType) {
+        return this.persistedStates.get(persistedStateType);
     }
 
 }

--- a/server/src/main/java/org/opensearch/cluster/coordination/PersistentStateRegistry.java
+++ b/server/src/main/java/org/opensearch/cluster/coordination/PersistentStateRegistry.java
@@ -1,0 +1,46 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.cluster.coordination;
+
+import org.opensearch.cluster.coordination.CoordinationState.PersistedState;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A class which encapsulates the PersistedStates
+ *
+ * @opensearch.internal
+ */
+public class PersistentStateRegistry {
+
+    private static final PersistentStateRegistry INSTANCE = new PersistentStateRegistry();
+
+    private PersistentStateRegistry() {}
+
+    /**
+     * Distinct Types PersistedState which can be present on a node
+     */
+    public enum PersistedStateType {
+        LOCAL,
+        REMOTE
+    }
+
+    private final Map<PersistedStateType, PersistedState> persistentStates = new HashMap<>();
+
+    public static void addPersistedState(PersistedStateType persistedStateType, PersistedState persistedState) {
+        PersistedState existingState = INSTANCE.persistentStates.putIfAbsent(persistedStateType, persistedState);
+        assert existingState == null : "should only be set once, but already have " + existingState;
+    }
+
+    public static PersistedState getPersistedState(PersistedStateType persistedStateType) {
+        return INSTANCE.persistentStates.get(persistedStateType);
+    }
+
+}

--- a/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/opensearch/common/settings/ClusterSettings.java
@@ -96,6 +96,7 @@ import org.opensearch.env.NodeEnvironment;
 import org.opensearch.gateway.DanglingIndicesState;
 import org.opensearch.gateway.GatewayService;
 import org.opensearch.gateway.PersistedClusterStateService;
+import org.opensearch.gateway.remote.RemoteClusterStateService;
 import org.opensearch.http.HttpTransportSettings;
 import org.opensearch.index.IndexModule;
 import org.opensearch.index.IndexSettings;
@@ -660,7 +661,11 @@ public final class ClusterSettings extends AbstractScopedSettings {
 
                 // Related to monitoring of task cancellation
                 TaskCancellationMonitoringSettings.IS_ENABLED_SETTING,
-                TaskCancellationMonitoringSettings.DURATION_MILLIS_SETTING
+                TaskCancellationMonitoringSettings.DURATION_MILLIS_SETTING,
+
+                // Remote cluster state settings
+                RemoteClusterStateService.REMOTE_CLUSTER_STATE_ENABLED_SETTING,
+                RemoteClusterStateService.REMOTE_CLUSTER_STATE_REPOSITORY_SETTING
             )
         )
     );

--- a/server/src/main/java/org/opensearch/discovery/DiscoveryModule.java
+++ b/server/src/main/java/org/opensearch/discovery/DiscoveryModule.java
@@ -37,6 +37,7 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.coordination.Coordinator;
 import org.opensearch.cluster.coordination.ElectionStrategy;
+import org.opensearch.cluster.coordination.PersistedStateRegistry;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.routing.RerouteService;
 import org.opensearch.cluster.routing.allocation.AllocationService;
@@ -129,7 +130,8 @@ public class DiscoveryModule {
         Path configFile,
         GatewayMetaState gatewayMetaState,
         RerouteService rerouteService,
-        NodeHealthService nodeHealthService
+        NodeHealthService nodeHealthService,
+        PersistedStateRegistry persistedStateRegistry
     ) {
         final Collection<BiConsumer<DiscoveryNode, ClusterState>> joinValidators = new ArrayList<>();
         final Map<String, Supplier<SeedHostsProvider>> hostProviders = new HashMap<>();
@@ -205,7 +207,8 @@ public class DiscoveryModule {
                 new Random(Randomness.get().nextLong()),
                 rerouteService,
                 electionStrategy,
-                nodeHealthService
+                nodeHealthService,
+                persistedStateRegistry
             );
         } else {
             throw new IllegalArgumentException("Unknown discovery type [" + discoveryType + "]");

--- a/server/src/main/java/org/opensearch/gateway/GatewayMetaState.java
+++ b/server/src/main/java/org/opensearch/gateway/GatewayMetaState.java
@@ -45,8 +45,8 @@ import org.opensearch.cluster.ClusterStateApplier;
 import org.opensearch.cluster.coordination.CoordinationMetadata;
 import org.opensearch.cluster.coordination.CoordinationState.PersistedState;
 import org.opensearch.cluster.coordination.InMemoryPersistedState;
-import org.opensearch.cluster.coordination.PersistentStateRegistry;
-import org.opensearch.cluster.coordination.PersistentStateRegistry.PersistedStateType;
+import org.opensearch.cluster.coordination.PersistedStateRegistry;
+import org.opensearch.cluster.coordination.PersistedStateRegistry.PersistedStateType;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.IndexTemplateMetadata;
 import org.opensearch.cluster.metadata.Manifest;
@@ -54,7 +54,6 @@ import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.metadata.MetadataIndexUpgradeService;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.service.ClusterService;
-import org.opensearch.common.SetOnce;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.AbstractRunnable;
@@ -84,6 +83,7 @@ import java.util.function.Function;
 import java.util.function.UnaryOperator;
 
 import static org.opensearch.common.util.concurrent.OpenSearchExecutors.daemonThreadFactory;
+import static org.opensearch.gateway.remote.RemoteClusterStateService.REMOTE_CLUSTER_STATE_ENABLED_SETTING;
 
 /**
  * Loads (and maybe upgrades) cluster metadata at startup, and persistently stores cluster metadata for future restarts.
@@ -104,17 +104,14 @@ public class GatewayMetaState implements Closeable {
      */
     public static final String STALE_STATE_CONFIG_NODE_ID = "STALE_STATE_CONFIG";
 
-    // Set by calling start()
-    private final SetOnce<PersistedState> persistedState = new SetOnce<>();
-
     public PersistedState getPersistedState() {
-        final PersistedState persistedState = PersistentStateRegistry.getPersistedState(PersistedStateType.LOCAL);
+        final PersistedState persistedState = PersistedStateRegistry.getPersistedState(PersistedStateType.LOCAL);
         assert persistedState != null : "not started";
         return persistedState;
     }
 
     public Metadata getMetadata() {
-        return PersistentStateRegistry.getPersistedState(PersistedStateType.LOCAL).getLastAcceptedState().metadata();
+        return PersistedStateRegistry.getPersistedState(PersistedStateType.LOCAL).getLastAcceptedState().metadata();
     }
 
     public void start(
@@ -127,8 +124,8 @@ public class GatewayMetaState implements Closeable {
         PersistedClusterStateService persistedClusterStateService,
         RemoteClusterStateService remoteClusterStateService
     ) {
-        assert PersistentStateRegistry.getPersistedState(PersistedStateType.LOCAL) == null : "should only start once, but already have "
-            + persistedState.get();
+        assert PersistedStateRegistry.getPersistedState(PersistedStateType.LOCAL) == null : "should only start once, but already have "
+            + PersistedStateRegistry.getPersistedState(PersistedStateType.LOCAL);
 
         if (DiscoveryNode.isClusterManagerNode(settings) || DiscoveryNode.isDataNode(settings)) {
             try {
@@ -164,7 +161,9 @@ public class GatewayMetaState implements Closeable {
 
                     if (DiscoveryNode.isClusterManagerNode(settings)) {
                         persistedState = new LucenePersistedState(persistedClusterStateService, currentTerm, clusterState);
-                        remotePersistedState = new RemotePersistedState(remoteClusterStateService);
+                        if (REMOTE_CLUSTER_STATE_ENABLED_SETTING.get(settings) == true) {
+                            remotePersistedState = new RemotePersistedState(remoteClusterStateService);
+                        }
                     } else {
                         persistedState = new AsyncLucenePersistedState(
                             settings,
@@ -186,11 +185,14 @@ public class GatewayMetaState implements Closeable {
                 } finally {
                     if (success == false) {
                         IOUtils.closeWhileHandlingException(persistedState);
+                        IOUtils.closeWhileHandlingException(remotePersistedState);
                     }
                 }
 
-                PersistentStateRegistry.addPersistedState(PersistedStateType.LOCAL, persistedState);
-                PersistentStateRegistry.addPersistedState(PersistedStateType.REMOTE, remotePersistedState);
+                PersistedStateRegistry.addPersistedState(PersistedStateType.LOCAL, persistedState);
+                if (remotePersistedState != null) {
+                    PersistedStateRegistry.addPersistedState(PersistedStateType.REMOTE, remotePersistedState);
+                }
             } catch (IOException e) {
                 throw new OpenSearchException("failed to load metadata", e);
             }
@@ -217,7 +219,7 @@ public class GatewayMetaState implements Closeable {
                     throw new UncheckedIOException(e);
                 }
             }
-            persistedState.set(new InMemoryPersistedState(currentTerm, clusterState));
+            PersistedStateRegistry.addPersistedState(PersistedStateType.LOCAL, new InMemoryPersistedState(currentTerm, clusterState));
         }
     }
 
@@ -336,12 +338,12 @@ public class GatewayMetaState implements Closeable {
 
     @Override
     public void close() throws IOException {
-        IOUtils.close(PersistentStateRegistry.getPersistedState(PersistedStateType.LOCAL));
+        IOUtils.close(PersistedStateRegistry.getPersistedState(PersistedStateType.LOCAL));
     }
 
     // visible for testing
     public boolean allPendingAsyncStatesWritten() {
-        final PersistedState ps = PersistentStateRegistry.getPersistedState(PersistedStateType.LOCAL);
+        final PersistedState ps = PersistedStateRegistry.getPersistedState(PersistedStateType.LOCAL);
         if (ps instanceof AsyncLucenePersistedState) {
             return ((AsyncLucenePersistedState) ps).allPendingAsyncStatesWritten();
         } else {

--- a/server/src/main/java/org/opensearch/gateway/GatewayMetaState.java
+++ b/server/src/main/java/org/opensearch/gateway/GatewayMetaState.java
@@ -695,7 +695,7 @@ public class GatewayMetaState implements Closeable {
 
         @Override
         public void close() throws IOException {
-            PersistedState.super.close();
+            remoteClusterStateService.close();
         }
 
         private void handleExceptionOnWrite(Exception e) {

--- a/server/src/main/java/org/opensearch/gateway/remote/ClusterMetadataMarker.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/ClusterMetadataMarker.java
@@ -1,0 +1,381 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.gateway.remote;
+
+import org.opensearch.Version;
+import org.opensearch.core.ParseField;
+import org.opensearch.core.common.Strings;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ConstructingObjectParser;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.core.xcontent.ToXContentFragment;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Marker file which contains the details of the uploaded entity metadata
+ *
+ * @opensearch.internal
+ */
+public class ClusterMetadataMarker implements Writeable, ToXContentFragment {
+
+    private static final ParseField CLUSTER_TERM_FIELD = new ParseField("cluster_term");
+    private static final ParseField STATE_VERSION_FIELD = new ParseField("state_version");
+    private static final ParseField CLUSTER_UUID_FIELD = new ParseField("cluster_uuid");
+    private static final ParseField STATE_UUID_FIELD = new ParseField("state_uuid");
+    private static final ParseField OPENSEARCH_VERSION_FIELD = new ParseField("opensearch_version");
+    private static final ParseField COMMITTED_FIELD = new ParseField("committed");
+    private static final ParseField INDICES_FIELD = new ParseField("indices");
+
+    private static long term(Object[] fields) {
+        return (long) fields[0];
+    }
+
+    private static long version(Object[] fields) {
+        return (long) fields[1];
+    }
+
+    private static String clusterUUID(Object[] fields) {
+        return (String) fields[2];
+    }
+
+    private static String stateUUID(Object[] fields) {
+        return (String) fields[3];
+    }
+
+    private static Version opensearchVersion(Object[] fields) {
+        return Version.fromId((int) fields[4]);
+    }
+
+    private static boolean committed(Object[] fields) {
+        return (boolean) fields[5];
+    }
+
+    private static List<UploadedIndexMetadata> indices(Object[] fields) {
+        return (List<UploadedIndexMetadata>) fields[6];
+    }
+
+    private static final ConstructingObjectParser<ClusterMetadataMarker, Void> PARSER = new ConstructingObjectParser<>(
+        "cluster_metadata_marker",
+        fields -> new ClusterMetadataMarker(
+            term(fields),
+            version(fields),
+            clusterUUID(fields),
+            stateUUID(fields),
+            opensearchVersion(fields),
+            committed(fields),
+            indices(fields)
+        )
+    );
+
+    static {
+        PARSER.declareLong(ConstructingObjectParser.constructorArg(), CLUSTER_TERM_FIELD);
+        PARSER.declareLong(ConstructingObjectParser.constructorArg(), STATE_VERSION_FIELD);
+        PARSER.declareString(ConstructingObjectParser.constructorArg(), CLUSTER_UUID_FIELD);
+        PARSER.declareString(ConstructingObjectParser.constructorArg(), STATE_UUID_FIELD);
+        PARSER.declareInt(ConstructingObjectParser.constructorArg(), OPENSEARCH_VERSION_FIELD);
+        PARSER.declareBoolean(ConstructingObjectParser.constructorArg(), COMMITTED_FIELD);
+        PARSER.declareObjectArray(
+            ConstructingObjectParser.constructorArg(),
+            (p, c) -> UploadedIndexMetadata.fromXContent(p),
+            INDICES_FIELD
+        );
+    }
+
+    private final List<UploadedIndexMetadata> indices;
+    private final long clusterTerm;
+    private final long stateVersion;
+    private final String clusterUUID;
+    private final String stateUUID;
+    private final Version opensearchVersion;
+    private final boolean committed;
+
+    public List<UploadedIndexMetadata> getIndices() {
+        return indices;
+    }
+
+    public long getClusterTerm() {
+        return clusterTerm;
+    }
+
+    public long getStateVersion() {
+        return stateVersion;
+    }
+
+    public String getClusterUUID() {
+        return clusterUUID;
+    }
+
+    public String getStateUUID() {
+        return stateUUID;
+    }
+
+    public Version getOpensearchVersion() {
+        return opensearchVersion;
+    }
+
+    public boolean isCommitted() {
+        return committed;
+    }
+
+    public ClusterMetadataMarker(
+        long clusterTerm,
+        long version,
+        String clusterUUID,
+        String stateUUID,
+        Version opensearchVersion,
+        boolean committed,
+        List<UploadedIndexMetadata> indices
+    ) {
+        this.clusterTerm = clusterTerm;
+        this.stateVersion = version;
+        this.clusterUUID = clusterUUID;
+        this.stateUUID = stateUUID;
+        this.opensearchVersion = opensearchVersion;
+        this.committed = committed;
+        this.indices = Collections.unmodifiableList(indices);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.field(CLUSTER_TERM_FIELD.getPreferredName(), getClusterTerm())
+            .field(STATE_VERSION_FIELD.getPreferredName(), getStateVersion())
+            .field(CLUSTER_UUID_FIELD.getPreferredName(), getClusterUUID())
+            .field(STATE_UUID_FIELD.getPreferredName(), getStateUUID())
+            .field(OPENSEARCH_VERSION_FIELD.getPreferredName(), getOpensearchVersion().id)
+            .field(COMMITTED_FIELD.getPreferredName(), isCommitted());
+        builder.startArray(INDICES_FIELD.getPreferredName());
+        {
+            for (UploadedIndexMetadata uploadedIndexMetadata : indices) {
+                uploadedIndexMetadata.toXContent(builder, params);
+            }
+        }
+        builder.endArray();
+        return builder;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVLong(clusterTerm);
+        out.writeVLong(stateVersion);
+        out.writeString(clusterUUID);
+        out.writeString(stateUUID);
+        out.writeInt(opensearchVersion.id);
+        out.writeBoolean(committed);
+        out.writeCollection(indices);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final ClusterMetadataMarker that = (ClusterMetadataMarker) o;
+        return Objects.equals(indices, that.indices)
+            && clusterTerm == that.clusterTerm
+            && stateVersion == that.stateVersion
+            && Objects.equals(clusterUUID, that.clusterUUID)
+            && Objects.equals(stateUUID, that.stateUUID)
+            && Objects.equals(opensearchVersion, that.opensearchVersion)
+            && Objects.equals(committed, that.committed);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(indices, clusterTerm, stateVersion, clusterUUID, stateUUID, opensearchVersion, committed);
+    }
+
+    @Override
+    public String toString() {
+        return Strings.toString(MediaTypeRegistry.JSON, this);
+    }
+
+    public static ClusterMetadataMarker fromXContent(XContentParser parser) throws IOException {
+        return PARSER.parse(parser, null);
+    }
+
+    /**
+     * Builder for ClusterMetadataMarker
+     *
+     * @opensearch.internal
+     */
+    public static class Builder {
+
+        private List<UploadedIndexMetadata> indices;
+        private long clusterTerm;
+        private long stateVersion;
+        private String clusterUUID;
+        private String stateUUID;
+        private Version opensearchVersion;
+        private boolean committed;
+
+        public Builder indices(List<UploadedIndexMetadata> indices) {
+            this.indices = indices;
+            return this;
+        }
+
+        public Builder clusterTerm(long clusterTerm) {
+            this.clusterTerm = clusterTerm;
+            return this;
+        }
+
+        public Builder stateVersion(long stateVersion) {
+            this.stateVersion = stateVersion;
+            return this;
+        }
+
+        public Builder clusterUUID(String clusterUUID) {
+            this.clusterUUID = clusterUUID;
+            return this;
+        }
+
+        public Builder stateUUID(String stateUUID) {
+            this.stateUUID = stateUUID;
+            return this;
+        }
+
+        public Builder opensearchVersion(Version opensearchVersion) {
+            this.opensearchVersion = opensearchVersion;
+            return this;
+        }
+
+        public Builder committed(boolean committed) {
+            this.committed = committed;
+            return this;
+        }
+
+        public List<UploadedIndexMetadata> getIndices() {
+            return indices;
+        }
+
+        public Builder() {
+            indices = new ArrayList<>();
+        }
+
+        public ClusterMetadataMarker build() {
+            return new ClusterMetadataMarker(clusterTerm, stateVersion, clusterUUID, stateUUID, opensearchVersion, committed, indices);
+        }
+
+    }
+
+    /**
+     * Metadata for uploaded index metadata
+     *
+     * @opensearch.internal
+     */
+    public static class UploadedIndexMetadata implements Writeable, ToXContentFragment {
+
+        private static final ParseField INDEX_NAME_FIELD = new ParseField("index_name");
+        private static final ParseField INDEX_UUID_FIELD = new ParseField("index_uuid");
+        private static final ParseField UPLOADED_FILENAME_FIELD = new ParseField("uploaded_filename");
+
+        private static String indexName(Object[] fields) {
+            return (String) fields[0];
+        }
+
+        private static String indexUUID(Object[] fields) {
+            return (String) fields[1];
+        }
+
+        private static String uploadedFilename(Object[] fields) {
+            return (String) fields[2];
+        }
+
+        private static final ConstructingObjectParser<UploadedIndexMetadata, Void> PARSER = new ConstructingObjectParser<>(
+            "uploaded_index_metadata",
+            fields -> new UploadedIndexMetadata(indexName(fields), indexUUID(fields), uploadedFilename(fields))
+        );
+
+        static {
+            PARSER.declareString(ConstructingObjectParser.constructorArg(), INDEX_NAME_FIELD);
+            PARSER.declareString(ConstructingObjectParser.constructorArg(), INDEX_UUID_FIELD);
+            PARSER.declareString(ConstructingObjectParser.constructorArg(), UPLOADED_FILENAME_FIELD);
+        }
+
+        private final String indexName;
+        private final String indexUUID;
+        private final String uploadedFilename;
+
+        public UploadedIndexMetadata(String indexName, String indexUUID, String uploadedFileName) {
+            this.indexName = indexName;
+            this.indexUUID = indexUUID;
+            this.uploadedFilename = uploadedFileName;
+        }
+
+        public String getUploadedFilename() {
+            return uploadedFilename;
+        }
+
+        public String getIndexName() {
+            return indexName;
+        }
+
+        public String getIndexUUID() {
+            return indexUUID;
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            return builder.startObject()
+                .field(INDEX_NAME_FIELD.getPreferredName(), getIndexName())
+                .field(INDEX_UUID_FIELD.getPreferredName(), getIndexUUID())
+                .field(UPLOADED_FILENAME_FIELD.getPreferredName(), getUploadedFilename())
+                .endObject();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeString(indexName);
+            out.writeString(indexUUID);
+            out.writeString(uploadedFilename);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            final UploadedIndexMetadata that = (UploadedIndexMetadata) o;
+            return Objects.equals(indexName, that.indexName)
+                && Objects.equals(indexUUID, that.indexUUID)
+                && Objects.equals(uploadedFilename, that.uploadedFilename);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(indexName, indexUUID, uploadedFilename);
+        }
+
+        @Override
+        public String toString() {
+            return Strings.toString(MediaTypeRegistry.JSON, this);
+        }
+
+        public static UploadedIndexMetadata fromXContent(XContentParser parser) throws IOException {
+            return PARSER.parse(parser, null);
+        }
+    }
+}

--- a/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/RemoteClusterStateService.java
@@ -1,0 +1,358 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.gateway.remote;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.Version;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.Nullable;
+import org.opensearch.common.blobstore.BlobContainer;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Setting.Property;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.gateway.remote.ClusterMetadataMarker.UploadedIndexMetadata;
+import org.opensearch.index.remote.RemoteStoreUtils;
+import org.opensearch.repositories.RepositoriesService;
+import org.opensearch.repositories.Repository;
+import org.opensearch.repositories.blobstore.BlobStoreRepository;
+import org.opensearch.repositories.blobstore.ChecksumBlobStoreFormat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static org.opensearch.gateway.PersistedClusterStateService.SLOW_WRITE_LOGGING_THRESHOLD;
+
+/**
+ * A Service which provides APIs to upload and download cluster metadata from remote store.
+ *
+ * @opensearch.internal
+ */
+public class RemoteClusterStateService {
+
+    public static final String METADATA_NAME_FORMAT = "%s.dat";
+
+    public static final String METADATA_MARKER_NAME_FORMAT = "%s";
+
+    public static final ChecksumBlobStoreFormat<IndexMetadata> INDEX_METADATA_FORMAT = new ChecksumBlobStoreFormat<>(
+        "index-metadata",
+        METADATA_NAME_FORMAT,
+        IndexMetadata::fromXContent
+    );
+
+    public static final ChecksumBlobStoreFormat<ClusterMetadataMarker> CLUSTER_METADATA_MARKER_FORMAT = new ChecksumBlobStoreFormat<>(
+        "cluster-metadata-marker",
+        METADATA_MARKER_NAME_FORMAT,
+        ClusterMetadataMarker::fromXContent
+    );
+    /**
+     * Used to specify if cluster state metadata should be publish to remote store
+     */
+    public static final Setting<Boolean> REMOTE_CLUSTER_STATE_ENABLED_SETTING = Setting.boolSetting(
+        "cluster.remote_store.state.enabled",
+        false,
+        Property.NodeScope,
+        Property.Final
+    );
+    /**
+     * Used to specify default repo to use for cluster state metadata upload
+     */
+    public static final Setting<String> REMOTE_CLUSTER_STATE_REPOSITORY_SETTING = Setting.simpleString(
+        "cluster.remote_store.state.repository",
+        "",
+        Property.NodeScope,
+        Property.Final
+    );
+    private static final Logger logger = LogManager.getLogger(RemoteClusterStateService.class);
+
+    private static final String DELIMITER = "__";
+
+    private final Supplier<RepositoriesService> repositoriesService;
+    private final Settings settings;
+    private final LongSupplier relativeTimeMillisSupplier;
+    private BlobStoreRepository blobStoreRepository;
+    private volatile TimeValue slowWriteLoggingThreshold;
+
+    public RemoteClusterStateService(
+        Supplier<RepositoriesService> repositoriesService,
+        Settings settings,
+        ClusterSettings clusterSettings,
+        LongSupplier relativeTimeMillisSupplier
+    ) {
+        this.repositoriesService = repositoriesService;
+        this.settings = settings;
+        this.relativeTimeMillisSupplier = relativeTimeMillisSupplier;
+        this.slowWriteLoggingThreshold = clusterSettings.get(SLOW_WRITE_LOGGING_THRESHOLD);
+        clusterSettings.addSettingsUpdateConsumer(SLOW_WRITE_LOGGING_THRESHOLD, this::setSlowWriteLoggingThreshold);
+    }
+
+    /**
+     * This method uploads entire cluster state metadata to the configured blob store. For now only index metadata upload is supported. This method should be
+     * invoked by the elected cluster manager when the remote cluster state is enabled.
+     *
+     * @return A metadata/marker object which contains the details of uploaded entity metadata.
+     */
+    @Nullable
+    public ClusterMetadataMarker writeFullMetadata(ClusterState clusterState) throws IOException {
+        final long startTimeMillis = relativeTimeMillisSupplier.getAsLong();
+        if (clusterState.nodes().isLocalNodeElectedClusterManager() == false) {
+            logger.error("Local node is not elected cluster manager. Exiting");
+            return null;
+        }
+        assert REMOTE_CLUSTER_STATE_ENABLED_SETTING.get(settings) == true : "Remote cluster state is not enabled";
+        ensureRepositorySet();
+
+        final List<ClusterMetadataMarker.UploadedIndexMetadata> allUploadedIndexMetadata = new ArrayList<>();
+        // todo parallel upload
+        // any validations before/after upload ?
+        for (IndexMetadata indexMetadata : clusterState.metadata().indices().values()) {
+            // 123456789012_test-cluster/cluster-state/dsgYj10Nkso7/index/ftqsCnn9TgOX/metadata_4_1690947200
+            final String indexMetadataKey = writeIndexMetadata(
+                clusterState.getClusterName().value(),
+                clusterState.getMetadata().clusterUUID(),
+                indexMetadata,
+                indexMetadataFileName(indexMetadata)
+            );
+            final UploadedIndexMetadata uploadedIndexMetadata = new UploadedIndexMetadata(
+                indexMetadata.getIndex().getName(),
+                indexMetadata.getIndexUUID(),
+                indexMetadataKey
+            );
+            allUploadedIndexMetadata.add(uploadedIndexMetadata);
+        }
+        final ClusterMetadataMarker marker = uploadMarker(clusterState, allUploadedIndexMetadata, false);
+        final long durationMillis = relativeTimeMillisSupplier.getAsLong() - startTimeMillis;
+        if (durationMillis >= slowWriteLoggingThreshold.getMillis()) {
+            logger.warn(
+                "writing cluster state took [{}ms] which is above the warn threshold of [{}]; " + "wrote full state with [{}] indices",
+                durationMillis,
+                slowWriteLoggingThreshold,
+                allUploadedIndexMetadata.size()
+            );
+        } else {
+            // todo change to debug
+            logger.info(
+                "writing cluster state took [{}ms]; " + "wrote full state with [{}] indices",
+                durationMillis,
+                allUploadedIndexMetadata.size()
+            );
+        }
+        return marker;
+    }
+
+    /**
+     * This method uploads the diff between the previous cluster state and the current cluster state. The previous marker file is needed to create the new
+     * marker. The new marker file is created by using the unchanged metadata from the previous marker and the new metadata changes from the current cluster
+     * state.
+     *
+     * @return The uploaded ClusterMetadataMarker file
+     */
+    @Nullable
+    public ClusterMetadataMarker writeIncrementalMetadata(
+        ClusterState previousClusterState,
+        ClusterState clusterState,
+        ClusterMetadataMarker previousMarker
+    ) throws IOException {
+        final long startTimeMillis = relativeTimeMillisSupplier.getAsLong();
+        if (clusterState.nodes().isLocalNodeElectedClusterManager() == false) {
+            logger.error("Local node is not elected cluster manager. Exiting");
+            return null;
+        }
+        assert previousClusterState.metadata().coordinationMetadata().term() == clusterState.metadata().coordinationMetadata().term();
+        assert REMOTE_CLUSTER_STATE_ENABLED_SETTING.get(settings) == true : "Remote cluster state is not enabled";
+        final Map<String, Long> previousStateIndexMetadataVersionByName = new HashMap<>();
+        for (final IndexMetadata indexMetadata : previousClusterState.metadata().indices().values()) {
+            previousStateIndexMetadataVersionByName.put(indexMetadata.getIndex().getName(), indexMetadata.getVersion());
+        }
+
+        int numIndicesUpdated = 0;
+        int numIndicesUnchanged = 0;
+        final Map<String, ClusterMetadataMarker.UploadedIndexMetadata> allUploadedIndexMetadata = previousMarker.getIndices()
+            .stream()
+            .collect(Collectors.toMap(UploadedIndexMetadata::getIndexName, Function.identity()));
+        for (final IndexMetadata indexMetadata : clusterState.metadata().indices().values()) {
+            final Long previousVersion = previousStateIndexMetadataVersionByName.get(indexMetadata.getIndex().getName());
+            if (previousVersion == null || indexMetadata.getVersion() != previousVersion) {
+                logger.trace(
+                    "updating metadata for [{}], changing version from [{}] to [{}]",
+                    indexMetadata.getIndex(),
+                    previousVersion,
+                    indexMetadata.getVersion()
+                );
+                numIndicesUpdated++;
+                final String indexMetadataKey = writeIndexMetadata(
+                    clusterState.getClusterName().value(),
+                    clusterState.getMetadata().clusterUUID(),
+                    indexMetadata,
+                    indexMetadataFileName(indexMetadata)
+                );
+                final UploadedIndexMetadata uploadedIndexMetadata = new UploadedIndexMetadata(
+                    indexMetadata.getIndex().getName(),
+                    indexMetadata.getIndexUUID(),
+                    indexMetadataKey
+                );
+                allUploadedIndexMetadata.put(indexMetadata.getIndex().getName(), uploadedIndexMetadata);
+            } else {
+                numIndicesUnchanged++;
+            }
+            previousStateIndexMetadataVersionByName.remove(indexMetadata.getIndex().getName());
+        }
+
+        for (String removedIndexName : previousStateIndexMetadataVersionByName.keySet()) {
+            allUploadedIndexMetadata.remove(removedIndexName);
+        }
+        final ClusterMetadataMarker marker = uploadMarker(
+            clusterState,
+            allUploadedIndexMetadata.values().stream().collect(Collectors.toList()),
+            false
+        );
+        final long durationMillis = relativeTimeMillisSupplier.getAsLong() - startTimeMillis;
+        if (durationMillis >= slowWriteLoggingThreshold.getMillis()) {
+            logger.warn(
+                "writing cluster state took [{}ms] which is above the warn threshold of [{}]; "
+                    + "wrote  metadata for [{}] indices and skipped [{}] unchanged indices",
+                durationMillis,
+                slowWriteLoggingThreshold,
+                numIndicesUpdated,
+                numIndicesUnchanged
+            );
+        } else {
+            // todo change to debug
+            logger.info(
+                "writing cluster state took [{}ms]; " + "wrote and metadata for [{}] indices and skipped [{}] unchanged indices",
+                durationMillis,
+                numIndicesUpdated,
+                numIndicesUnchanged
+            );
+        }
+        return marker;
+    }
+
+    @Nullable
+    public ClusterMetadataMarker markLastStateAsCommitted(ClusterState clusterState, ClusterMetadataMarker previousMarker)
+        throws IOException {
+        if (clusterState.nodes().isLocalNodeElectedClusterManager() == false) {
+            logger.error("Local node is not elected cluster manager. Exiting");
+            return null;
+        }
+        assert clusterState != null : "Last accepted cluster state is not set";
+        assert previousMarker != null : "Last cluster metadata marker is not set";
+        assert REMOTE_CLUSTER_STATE_ENABLED_SETTING.get(settings) == true : "Remote cluster state is not enabled";
+        return uploadMarker(clusterState, previousMarker.getIndices(), true);
+    }
+
+    public ClusterState getLatestClusterState(String clusterUUID) {
+        // todo
+        return null;
+    }
+
+    // Visible for testing
+    void ensureRepositorySet() {
+        if (blobStoreRepository != null) {
+            return;
+        }
+        final String remoteStoreRepo = REMOTE_CLUSTER_STATE_REPOSITORY_SETTING.get(settings);
+        assert remoteStoreRepo != null : "Remote Cluster State repository is not configured";
+        final Repository repository = repositoriesService.get().repository(remoteStoreRepo);
+        assert repository instanceof BlobStoreRepository : "Repository should be instance of BlobStoreRepository";
+        blobStoreRepository = (BlobStoreRepository) repository;
+    }
+
+    private ClusterMetadataMarker uploadMarker(
+        ClusterState clusterState,
+        List<UploadedIndexMetadata> uploadedIndexMetadata,
+        boolean committed
+    ) throws IOException {
+        synchronized (this) {
+            final String markerFileName = getMarkerFileName(clusterState.term(), clusterState.version());
+            final ClusterMetadataMarker marker = new ClusterMetadataMarker(
+                clusterState.term(),
+                clusterState.getVersion(),
+                clusterState.metadata().clusterUUID(),
+                clusterState.stateUUID(),
+                Version.CURRENT,
+                committed,
+                uploadedIndexMetadata
+            );
+            writeMetadataMarker(clusterState.getClusterName().value(), clusterState.metadata().clusterUUID(), marker, markerFileName);
+            return marker;
+        }
+    }
+
+    private String writeIndexMetadata(String clusterName, String clusterUUID, IndexMetadata uploadIndexMetadata, String fileName)
+        throws IOException {
+        final BlobContainer indexMetadataContainer = indexMetadataContainer(clusterName, clusterUUID, uploadIndexMetadata.getIndexUUID());
+        INDEX_METADATA_FORMAT.write(uploadIndexMetadata, indexMetadataContainer, fileName, blobStoreRepository.getCompressor());
+        // returning full path
+        return indexMetadataContainer.path().buildAsString() + fileName;
+    }
+
+    private void writeMetadataMarker(String clusterName, String clusterUUID, ClusterMetadataMarker uploadMarker, String fileName)
+        throws IOException {
+        final BlobContainer metadataMarkerContainer = markerContainer(clusterName, clusterUUID);
+        CLUSTER_METADATA_MARKER_FORMAT.write(uploadMarker, metadataMarkerContainer, fileName, blobStoreRepository.getCompressor());
+    }
+
+    private BlobContainer indexMetadataContainer(String clusterName, String clusterUUID, String indexUUID) {
+        // 123456789012_test-cluster/cluster-state/dsgYj10Nkso7/index/ftqsCnn9TgOX
+        return blobStoreRepository.blobStore()
+            .blobContainer(
+                blobStoreRepository.basePath()
+                    .add(Base64.getUrlEncoder().withoutPadding().encodeToString(clusterName.getBytes(StandardCharsets.UTF_8)))
+                    .add("cluster-state")
+                    .add(clusterUUID)
+                    .add("index")
+                    .add(indexUUID)
+            );
+    }
+
+    private BlobContainer markerContainer(String clusterName, String clusterUUID) {
+        // 123456789012_test-cluster/cluster-state/dsgYj10Nkso7/marker
+        return blobStoreRepository.blobStore()
+            .blobContainer(
+                blobStoreRepository.basePath()
+                    .add(Base64.getUrlEncoder().withoutPadding().encodeToString(clusterName.getBytes(StandardCharsets.UTF_8)))
+                    .add("cluster-state")
+                    .add(clusterUUID)
+                    .add("marker")
+            );
+    }
+
+    private void setSlowWriteLoggingThreshold(TimeValue slowWriteLoggingThreshold) {
+        this.slowWriteLoggingThreshold = slowWriteLoggingThreshold;
+    }
+
+    private static String getMarkerFileName(long term, long version) {
+        // 123456789012_test-cluster/cluster-state/dsgYj10Nkso7/marker/2147483642_2147483637_456536447_marker
+        return String.join(
+            DELIMITER,
+            "marker",
+            RemoteStoreUtils.invertLong(term),
+            RemoteStoreUtils.invertLong(version),
+            RemoteStoreUtils.invertLong(System.currentTimeMillis())
+        );
+    }
+
+    private static String indexMetadataFileName(IndexMetadata indexMetadata) {
+        return String.join(DELIMITER, "metadata", String.valueOf(indexMetadata.getVersion()), String.valueOf(System.currentTimeMillis()));
+    }
+
+}

--- a/server/src/main/java/org/opensearch/gateway/remote/package-info.java
+++ b/server/src/main/java/org/opensearch/gateway/remote/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * Package containing class to perform operations on remote cluster state
+ */
+package org.opensearch.gateway.remote;

--- a/server/src/main/java/org/opensearch/node/Node.java
+++ b/server/src/main/java/org/opensearch/node/Node.java
@@ -61,8 +61,8 @@ import org.opensearch.cluster.ClusterStateObserver;
 import org.opensearch.cluster.InternalClusterInfoService;
 import org.opensearch.cluster.NodeConnectionsService;
 import org.opensearch.cluster.action.index.MappingUpdatedAction;
-import org.opensearch.cluster.coordination.PersistentStateRegistry;
-import org.opensearch.cluster.coordination.PersistentStateRegistry.PersistedStateType;
+import org.opensearch.cluster.coordination.PersistedStateRegistry;
+import org.opensearch.cluster.coordination.PersistedStateRegistry.PersistedStateType;
 import org.opensearch.cluster.metadata.AliasValidator;
 import org.opensearch.cluster.metadata.IndexTemplateMetadata;
 import org.opensearch.cluster.metadata.Metadata;
@@ -673,6 +673,7 @@ public class Node implements Closeable {
                 threadPool::relativeTimeInMillis
             );
             final RemoteClusterStateService remoteClusterStateService = new RemoteClusterStateService(
+                nodeEnvironment.nodeId(),
                 repositoriesServiceReference::get,
                 settings,
                 clusterService.getClusterSettings(),
@@ -1332,7 +1333,7 @@ public class Node implements Closeable {
         }
         // we load the global state here (the persistent part of the cluster state stored on disk) to
         // pass it to the bootstrap checks to allow plugins to enforce certain preconditions based on the recovered state.
-        final Metadata onDiskMetadata = PersistentStateRegistry.getPersistedState(PersistedStateType.LOCAL)
+        final Metadata onDiskMetadata = PersistedStateRegistry.getPersistedState(PersistedStateType.LOCAL)
             .getLastAcceptedState()
             .metadata();
         assert onDiskMetadata != null : "metadata is null but shouldn't"; // this is never null

--- a/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/opensearch/repositories/blobstore/BlobStoreRepository.java
@@ -801,6 +801,10 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         return metadata;
     }
 
+    public Compressor getCompressor() {
+        return compressor;
+    }
+
     @Override
     public RepositoryStats stats() {
         final BlobStore store = blobStore.get();

--- a/server/src/test/java/org/opensearch/cluster/coordination/NodeJoinTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/NodeJoinTests.java
@@ -260,7 +260,8 @@ public class NodeJoinTests extends OpenSearchTestCase {
             random,
             (s, p, r) -> {},
             ElectionStrategy.DEFAULT_INSTANCE,
-            nodeHealthService
+            nodeHealthService,
+            new PersistedStateRegistry()
         );
         transportService.start();
         transportService.acceptIncomingRequests();

--- a/server/src/test/java/org/opensearch/cluster/coordination/PreVoteCollectorTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/PreVoteCollectorTests.java
@@ -293,7 +293,9 @@ public class PreVoteCollectorTests extends OpenSearchTestCase {
         final CoordinationState coordinationState = new CoordinationState(
             localNode,
             new InMemoryPersistedState(currentTerm, makeClusterState(votingNodes)),
-            ElectionStrategy.DEFAULT_INSTANCE
+            ElectionStrategy.DEFAULT_INSTANCE,
+            new InMemoryPersistedState(currentTerm, makeClusterState(votingNodes)),
+            Settings.EMPTY
         );
 
         final long newTerm = randomLongBetween(currentTerm + 1, Long.MAX_VALUE);

--- a/server/src/test/java/org/opensearch/cluster/coordination/PublicationTests.java
+++ b/server/src/test/java/org/opensearch/cluster/coordination/PublicationTests.java
@@ -94,7 +94,9 @@ public class PublicationTests extends OpenSearchTestCase {
             coordinationState = new CoordinationState(
                 localNode,
                 new InMemoryPersistedState(0L, initialState),
-                ElectionStrategy.DEFAULT_INSTANCE
+                ElectionStrategy.DEFAULT_INSTANCE,
+                new InMemoryPersistedState(0L, initialState),
+                Settings.EMPTY
             );
         }
 

--- a/server/src/test/java/org/opensearch/discovery/DiscoveryModuleTests.java
+++ b/server/src/test/java/org/opensearch/discovery/DiscoveryModuleTests.java
@@ -34,6 +34,7 @@ package org.opensearch.discovery;
 import org.opensearch.Version;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.coordination.Coordinator;
+import org.opensearch.cluster.coordination.PersistedStateRegistry;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.routing.RerouteService;
 import org.opensearch.cluster.service.ClusterApplier;
@@ -120,7 +121,8 @@ public class DiscoveryModuleTests extends OpenSearchTestCase {
             createTempDir().toAbsolutePath(),
             gatewayMetaState,
             mock(RerouteService.class),
-            null
+            null,
+            new PersistedStateRegistry()
         );
     }
 

--- a/server/src/test/java/org/opensearch/gateway/GatewayMetaStatePersistedStateTests.java
+++ b/server/src/test/java/org/opensearch/gateway/GatewayMetaStatePersistedStateTests.java
@@ -429,6 +429,7 @@ public class GatewayMetaStatePersistedStateTests extends OpenSearchTestCase {
                 () -> 0L
             );
             final RemoteClusterStateService remoteClusterStateService = new RemoteClusterStateService(
+                nodeEnvironment.nodeId(),
                 () -> new RepositoriesService(
                     settings,
                     clusterService,

--- a/server/src/test/java/org/opensearch/gateway/GatewayMetaStatePersistedStateTests.java
+++ b/server/src/test/java/org/opensearch/gateway/GatewayMetaStatePersistedStateTests.java
@@ -41,6 +41,7 @@ import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.coordination.CoordinationMetadata;
 import org.opensearch.cluster.coordination.CoordinationMetadata.VotingConfigExclusion;
 import org.opensearch.cluster.coordination.CoordinationState;
+import org.opensearch.cluster.coordination.PersistedStateRegistry;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.Manifest;
 import org.opensearch.cluster.metadata.Metadata;
@@ -450,7 +451,8 @@ public class GatewayMetaStatePersistedStateTests extends OpenSearchTestCase {
                 null,
                 null,
                 persistedClusterStateService,
-                remoteClusterStateService
+                remoteClusterStateService,
+                new PersistedStateRegistry()
             );
             final CoordinationState.PersistedState persistedState = gateway.getPersistedState();
             assertThat(persistedState, instanceOf(GatewayMetaState.AsyncLucenePersistedState.class));

--- a/server/src/test/java/org/opensearch/gateway/remote/ClusterMetadataMarkerTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/ClusterMetadataMarkerTests.java
@@ -1,0 +1,46 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.gateway.remote;
+
+import org.opensearch.Version;
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.gateway.remote.ClusterMetadataMarker.UploadedIndexMetadata;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.util.Collections;
+
+public class ClusterMetadataMarkerTests extends OpenSearchTestCase {
+
+    public void testXContent() throws IOException {
+        UploadedIndexMetadata uploadedIndexMetadata = new UploadedIndexMetadata("test-index", "test-uuid", "/test/upload/path");
+        ClusterMetadataMarker originalMarker = new ClusterMetadataMarker(
+            1L,
+            1L,
+            "test-cluster-uuid",
+            "test-state-uuid",
+            Version.CURRENT,
+            false,
+            Collections.singletonList(uploadedIndexMetadata)
+        );
+        final XContentBuilder builder = JsonXContent.contentBuilder();
+        builder.startObject();
+        originalMarker.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
+
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, BytesReference.bytes(builder))) {
+            final ClusterMetadataMarker fromXContentMarker = ClusterMetadataMarker.fromXContent(parser);
+            assertEquals(originalMarker, fromXContentMarker);
+        }
+    }
+}

--- a/server/src/test/java/org/opensearch/gateway/remote/ClusterMetadataMarkerTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/ClusterMetadataMarkerTests.java
@@ -11,18 +11,23 @@ package org.opensearch.gateway.remote;
 import org.opensearch.Version;
 import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.gateway.remote.ClusterMetadataMarker.UploadedIndexMetadata;
+import org.opensearch.test.EqualsHashCodeTestUtils;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.test.VersionUtils;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 public class ClusterMetadataMarkerTests extends OpenSearchTestCase {
 
-    public void testXContent() throws IOException {
+    public void testClusterMetadataMarkerXContent() throws IOException {
         UploadedIndexMetadata uploadedIndexMetadata = new UploadedIndexMetadata("test-index", "test-uuid", "/test/upload/path");
         ClusterMetadataMarker originalMarker = new ClusterMetadataMarker(
             1L,
@@ -30,6 +35,7 @@ public class ClusterMetadataMarkerTests extends OpenSearchTestCase {
             "test-cluster-uuid",
             "test-state-uuid",
             Version.CURRENT,
+            "test-node-id",
             false,
             Collections.singletonList(uploadedIndexMetadata)
         );
@@ -42,5 +48,98 @@ public class ClusterMetadataMarkerTests extends OpenSearchTestCase {
             final ClusterMetadataMarker fromXContentMarker = ClusterMetadataMarker.fromXContent(parser);
             assertEquals(originalMarker, fromXContentMarker);
         }
+    }
+
+    public void testClusterMetadataMarkerSerializationEqualsHashCode() {
+        ClusterMetadataMarker initialMarker = new ClusterMetadataMarker(
+            randomNonNegativeLong(),
+            randomNonNegativeLong(),
+            randomAlphaOfLength(10),
+            randomAlphaOfLength(10),
+            VersionUtils.randomOpenSearchVersion(random()),
+            randomAlphaOfLength(10),
+            randomBoolean(),
+            randomUploadedIndexMetadataList()
+        );
+        EqualsHashCodeTestUtils.checkEqualsAndHashCode(
+            initialMarker,
+            orig -> OpenSearchTestCase.copyWriteable(orig, new NamedWriteableRegistry(Collections.emptyList()), ClusterMetadataMarker::new),
+            marker -> {
+                ClusterMetadataMarker.Builder builder = ClusterMetadataMarker.builder(marker);
+                switch (randomInt(7)) {
+                    case 0:
+                        builder.clusterTerm(randomNonNegativeLong());
+                        break;
+                    case 1:
+                        builder.stateVersion(randomNonNegativeLong());
+                        break;
+                    case 2:
+                        builder.clusterUUID(randomAlphaOfLength(10));
+                        break;
+                    case 3:
+                        builder.stateUUID(randomAlphaOfLength(10));
+                        break;
+                    case 4:
+                        builder.opensearchVersion(VersionUtils.randomOpenSearchVersion(random()));
+                        break;
+                    case 5:
+                        builder.nodeId(randomAlphaOfLength(10));
+                        break;
+                    case 6:
+                        builder.committed(randomBoolean());
+                        break;
+                    case 7:
+                        builder.indices(randomUploadedIndexMetadataList());
+                        break;
+                }
+                return builder.build();
+            }
+        );
+    }
+
+    private List<UploadedIndexMetadata> randomUploadedIndexMetadataList() {
+        final int size = randomIntBetween(1, 10);
+        final List<UploadedIndexMetadata> uploadedIndexMetadataList = new ArrayList<>(size);
+        while (uploadedIndexMetadataList.size() < size) {
+            assertTrue(uploadedIndexMetadataList.add(randomUploadedIndexMetadata()));
+        }
+        return uploadedIndexMetadataList;
+    }
+
+    private UploadedIndexMetadata randomUploadedIndexMetadata() {
+        return new UploadedIndexMetadata(randomAlphaOfLength(10), randomAlphaOfLength(10), randomAlphaOfLength(10));
+    }
+
+    public void testUploadedIndexMetadataSerializationEqualsHashCode() {
+        UploadedIndexMetadata uploadedIndexMetadata = new UploadedIndexMetadata("test-index", "test-uuid", "/test/upload/path");
+        EqualsHashCodeTestUtils.checkEqualsAndHashCode(
+            uploadedIndexMetadata,
+            orig -> OpenSearchTestCase.copyWriteable(orig, new NamedWriteableRegistry(Collections.emptyList()), UploadedIndexMetadata::new),
+            metadata -> randomlyChangingUploadedIndexMetadata(uploadedIndexMetadata)
+        );
+    }
+
+    private UploadedIndexMetadata randomlyChangingUploadedIndexMetadata(UploadedIndexMetadata uploadedIndexMetadata) {
+        switch (randomInt(2)) {
+            case 0:
+                return new UploadedIndexMetadata(
+                    randomAlphaOfLength(10),
+                    uploadedIndexMetadata.getIndexUUID(),
+                    uploadedIndexMetadata.getUploadedFilename()
+                );
+            case 1:
+                return new UploadedIndexMetadata(
+                    uploadedIndexMetadata.getIndexName(),
+                    randomAlphaOfLength(10),
+                    uploadedIndexMetadata.getUploadedFilename()
+                );
+            case 2:
+                return new UploadedIndexMetadata(
+                    uploadedIndexMetadata.getIndexName(),
+                    uploadedIndexMetadata.getIndexUUID(),
+                    randomAlphaOfLength(10)
+                );
+        }
+        return uploadedIndexMetadata;
     }
 }

--- a/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
@@ -1,0 +1,254 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.gateway.remote;
+
+import org.opensearch.Version;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.coordination.CoordinationMetadata;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.node.DiscoveryNodes;
+import org.opensearch.common.blobstore.BlobContainer;
+import org.opensearch.common.blobstore.BlobPath;
+import org.opensearch.common.blobstore.BlobStore;
+import org.opensearch.common.compress.DeflateCompressor;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.index.Index;
+import org.opensearch.gateway.remote.ClusterMetadataMarker.UploadedIndexMetadata;
+import org.opensearch.repositories.FilterRepository;
+import org.opensearch.repositories.RepositoriesService;
+import org.opensearch.repositories.RepositoryMissingException;
+import org.opensearch.repositories.blobstore.BlobStoreRepository;
+import org.opensearch.test.OpenSearchTestCase;
+import org.junit.Assert;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.mockito.ArgumentMatchers;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
+
+    private RemoteClusterStateService remoteClusterStateService;
+    private Supplier<RepositoriesService> repositoriesServiceSupplier;
+    private RepositoriesService repositoriesService;
+    private BlobStoreRepository blobStoreRepository;
+
+    @Before
+    public void setup() {
+        repositoriesServiceSupplier = mock(Supplier.class);
+        repositoriesService = mock(RepositoriesService.class);
+        when(repositoriesServiceSupplier.get()).thenReturn(repositoriesService);
+        final Settings settings = Settings.builder()
+            .put(RemoteClusterStateService.REMOTE_CLUSTER_STATE_ENABLED_SETTING.getKey(), true)
+            .put(RemoteClusterStateService.REMOTE_CLUSTER_STATE_REPOSITORY_SETTING.getKey(), "remote_store_repository")
+            .build();
+        blobStoreRepository = mock(BlobStoreRepository.class);
+        when(repositoriesService.repository("remote_store_repository")).thenReturn(blobStoreRepository);
+        remoteClusterStateService = new RemoteClusterStateService(
+            repositoriesServiceSupplier,
+            settings,
+            new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
+            () -> 0L
+        );
+    }
+
+    public void testFailWriteFullMetadataNonClusterManagerNode() throws IOException {
+        final ClusterState clusterState = generateClusterStateWithOneIndex().build();
+        final ClusterMetadataMarker marker = remoteClusterStateService.writeFullMetadata(clusterState);
+        Assert.assertThat(marker, nullValue());
+    }
+
+    public void testFailWriteFullMetadataWhenRemoteStateDisabled() throws IOException {
+        final Settings settings = Settings.builder().build();
+        remoteClusterStateService = spy(
+            new RemoteClusterStateService(
+                repositoriesServiceSupplier,
+                settings,
+                new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
+                () -> 0L
+            )
+        );
+        final ClusterState clusterState = generateClusterStateWithOneIndex().nodes(nodesWithLocalNodeClusterManager()).build();
+        assertThrows(AssertionError.class, () -> remoteClusterStateService.writeFullMetadata(clusterState));
+    }
+
+    public void testFailWriteFullMetadataWhenRepositoryNotSet() {
+        final ClusterState clusterState = generateClusterStateWithOneIndex().nodes(nodesWithLocalNodeClusterManager()).build();
+        doThrow(new RepositoryMissingException("repository missing")).when(repositoriesService).repository("remote_store_repository");
+        assertThrows(RepositoryMissingException.class, () -> remoteClusterStateService.writeFullMetadata(clusterState));
+    }
+
+    public void testFailWriteFullMetadataWhenNotBlobRepository() {
+        final FilterRepository filterRepository = mock(FilterRepository.class);
+        when(repositoriesService.repository("remote_store_repository")).thenReturn(filterRepository);
+        final ClusterState clusterState = generateClusterStateWithOneIndex().nodes(nodesWithLocalNodeClusterManager()).build();
+        assertThrows(AssertionError.class, () -> remoteClusterStateService.writeFullMetadata(clusterState));
+    }
+
+    public void testWriteFullMetadataSuccess() throws IOException {
+        final ClusterState clusterState = generateClusterStateWithOneIndex().nodes(nodesWithLocalNodeClusterManager()).build();
+        mockBlobStoreObjects();
+        final ClusterMetadataMarker marker = remoteClusterStateService.writeFullMetadata(clusterState);
+        final UploadedIndexMetadata uploadedIndexMetadata = new UploadedIndexMetadata("test-index", "index-uuid", "metadata-filename");
+        List<UploadedIndexMetadata> indices = List.of(uploadedIndexMetadata);
+
+        final ClusterMetadataMarker expectedMarker = ClusterMetadataMarker.builder()
+            .indices(indices)
+            .clusterTerm(1L)
+            .stateVersion(1L)
+            .stateUUID("state-uuid")
+            .clusterUUID("cluster-uuid")
+            .build();
+
+        assertThat(marker.getIndices().size(), is(1));
+        assertThat(marker.getIndices().get(0).getIndexName(), is(uploadedIndexMetadata.getIndexName()));
+        assertThat(marker.getIndices().get(0).getIndexUUID(), is(uploadedIndexMetadata.getIndexUUID()));
+        assertThat(marker.getIndices().get(0).getUploadedFilename(), notNullValue());
+        assertThat(marker.getClusterTerm(), is(expectedMarker.getClusterTerm()));
+        assertThat(marker.getStateVersion(), is(expectedMarker.getStateVersion()));
+        assertThat(marker.getClusterUUID(), is(expectedMarker.getClusterUUID()));
+        assertThat(marker.getStateUUID(), is(expectedMarker.getStateUUID()));
+    }
+
+    public void testFailWriteIncrementalMetadataNonClusterManagerNode() throws IOException {
+        final ClusterState clusterState = generateClusterStateWithOneIndex().build();
+        final ClusterMetadataMarker marker = remoteClusterStateService.writeIncrementalMetadata(clusterState, clusterState, null);
+        Assert.assertThat(marker, nullValue());
+    }
+
+    public void testFailWriteIncrementalMetadataWhenTermChanged() {
+        final ClusterState clusterState = generateClusterStateWithOneIndex().nodes(nodesWithLocalNodeClusterManager()).build();
+        final CoordinationMetadata coordinationMetadata = CoordinationMetadata.builder().term(2L).build();
+        final ClusterState previousClusterState = ClusterState.builder(ClusterName.DEFAULT)
+            .metadata(Metadata.builder().coordinationMetadata(coordinationMetadata))
+            .build();
+        assertThrows(
+            AssertionError.class,
+            () -> remoteClusterStateService.writeIncrementalMetadata(previousClusterState, clusterState, null)
+        );
+    }
+
+    public void testWriteIncrementalMetadataSuccess() throws IOException {
+        final ClusterState clusterState = generateClusterStateWithOneIndex().nodes(nodesWithLocalNodeClusterManager()).build();
+        mockBlobStoreObjects();
+        final CoordinationMetadata coordinationMetadata = CoordinationMetadata.builder().term(1L).build();
+        final ClusterState previousClusterState = ClusterState.builder(ClusterName.DEFAULT)
+            .metadata(Metadata.builder().coordinationMetadata(coordinationMetadata))
+            .build();
+
+        final ClusterMetadataMarker previousMarker = ClusterMetadataMarker.builder().indices(Collections.emptyList()).build();
+
+        remoteClusterStateService.ensureRepositorySet();
+        final ClusterMetadataMarker marker = remoteClusterStateService.writeIncrementalMetadata(
+            previousClusterState,
+            clusterState,
+            previousMarker
+        );
+        final UploadedIndexMetadata uploadedIndexMetadata = new UploadedIndexMetadata("test-index", "index-uuid", "metadata-filename");
+        final List<UploadedIndexMetadata> indices = List.of(uploadedIndexMetadata);
+
+        final ClusterMetadataMarker expectedMarker = ClusterMetadataMarker.builder()
+            .indices(indices)
+            .clusterTerm(1L)
+            .stateVersion(1L)
+            .stateUUID("state-uuid")
+            .clusterUUID("cluster-uuid")
+            .build();
+
+        assertThat(marker.getIndices().size(), is(1));
+        assertThat(marker.getIndices().get(0).getIndexName(), is(uploadedIndexMetadata.getIndexName()));
+        assertThat(marker.getIndices().get(0).getIndexUUID(), is(uploadedIndexMetadata.getIndexUUID()));
+        assertThat(marker.getIndices().get(0).getUploadedFilename(), notNullValue());
+        assertThat(marker.getClusterTerm(), is(expectedMarker.getClusterTerm()));
+        assertThat(marker.getStateVersion(), is(expectedMarker.getStateVersion()));
+        assertThat(marker.getClusterUUID(), is(expectedMarker.getClusterUUID()));
+        assertThat(marker.getStateUUID(), is(expectedMarker.getStateUUID()));
+    }
+
+    public void testMarkLastStateAsCommittedSuccess() throws IOException {
+        final ClusterState clusterState = generateClusterStateWithOneIndex().nodes(nodesWithLocalNodeClusterManager()).build();
+        mockBlobStoreObjects();
+        remoteClusterStateService.ensureRepositorySet();
+        final UploadedIndexMetadata uploadedIndexMetadata = new UploadedIndexMetadata("test-index", "index-uuid", "metadata-filename");
+        List<UploadedIndexMetadata> indices = List.of(uploadedIndexMetadata);
+        final ClusterMetadataMarker previousMarker = ClusterMetadataMarker.builder().indices(indices).build();
+
+        final ClusterMetadataMarker marker = remoteClusterStateService.markLastStateAsCommitted(clusterState, previousMarker);
+
+        final ClusterMetadataMarker expectedMarker = ClusterMetadataMarker.builder()
+            .indices(indices)
+            .clusterTerm(1L)
+            .stateVersion(1L)
+            .stateUUID("state-uuid")
+            .clusterUUID("cluster-uuid")
+            .build();
+
+        assertThat(marker.getIndices().size(), is(1));
+        assertThat(marker.getIndices().get(0).getIndexName(), is(uploadedIndexMetadata.getIndexName()));
+        assertThat(marker.getIndices().get(0).getIndexUUID(), is(uploadedIndexMetadata.getIndexUUID()));
+        assertThat(marker.getIndices().get(0).getUploadedFilename(), notNullValue());
+        assertThat(marker.getClusterTerm(), is(expectedMarker.getClusterTerm()));
+        assertThat(marker.getStateVersion(), is(expectedMarker.getStateVersion()));
+        assertThat(marker.getClusterUUID(), is(expectedMarker.getClusterUUID()));
+        assertThat(marker.getStateUUID(), is(expectedMarker.getStateUUID()));
+    }
+
+    private void mockBlobStoreObjects() {
+        final BlobStore blobStore = mock(BlobStore.class);
+        when(blobStoreRepository.blobStore()).thenReturn(blobStore);
+        final BlobPath blobPath = mock(BlobPath.class);
+        when((blobStoreRepository.basePath())).thenReturn(blobPath);
+        when(blobPath.add(anyString())).thenReturn(blobPath);
+        when(blobPath.buildAsString()).thenReturn("/blob/path/");
+        final BlobContainer blobContainer = mock(BlobContainer.class);
+        when(blobContainer.path()).thenReturn(blobPath);
+        when(blobStore.blobContainer(ArgumentMatchers.any())).thenReturn(blobContainer);
+        when(blobStoreRepository.getCompressor()).thenReturn(new DeflateCompressor());
+    }
+
+    private static ClusterState.Builder generateClusterStateWithOneIndex() {
+        final Index index = new Index("test-index", "index-uuid");
+        final Settings idxSettings = Settings.builder()
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexMetadata.SETTING_INDEX_UUID, index.getUUID())
+            .build();
+        final IndexMetadata indexMetadata = new IndexMetadata.Builder(index.getName()).settings(idxSettings)
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+        final CoordinationMetadata coordinationMetadata = CoordinationMetadata.builder().term(1L).build();
+
+        return ClusterState.builder(ClusterName.DEFAULT)
+            .version(1L)
+            .stateUUID("state-uuid")
+            .metadata(
+                Metadata.builder().put(indexMetadata, true).clusterUUID("cluster-uuid").coordinationMetadata(coordinationMetadata).build()
+            );
+    }
+
+    private static DiscoveryNodes nodesWithLocalNodeClusterManager() {
+        return DiscoveryNodes.builder().clusterManagerNodeId("cluster-manager-id").localNodeId("cluster-manager-id").build();
+    }
+
+}

--- a/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
+++ b/server/src/test/java/org/opensearch/gateway/remote/RemoteClusterStateServiceTests.java
@@ -66,6 +66,7 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
         blobStoreRepository = mock(BlobStoreRepository.class);
         when(repositoriesService.repository("remote_store_repository")).thenReturn(blobStoreRepository);
         remoteClusterStateService = new RemoteClusterStateService(
+            "test-node-id",
             repositoriesServiceSupplier,
             settings,
             new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
@@ -83,6 +84,7 @@ public class RemoteClusterStateServiceTests extends OpenSearchTestCase {
         final Settings settings = Settings.builder().build();
         remoteClusterStateService = spy(
             new RemoteClusterStateService(
+                "test-node-id",
                 repositoriesServiceSupplier,
                 settings,
                 new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),

--- a/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/opensearch/snapshots/SnapshotResiliencyTests.java
@@ -130,6 +130,7 @@ import org.opensearch.cluster.coordination.DeterministicTaskQueue;
 import org.opensearch.cluster.coordination.ElectionStrategy;
 import org.opensearch.cluster.coordination.InMemoryPersistedState;
 import org.opensearch.cluster.coordination.MockSinglePrioritizingExecutor;
+import org.opensearch.cluster.coordination.PersistedStateRegistry;
 import org.opensearch.cluster.metadata.AliasValidator;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
@@ -2506,7 +2507,8 @@ public class SnapshotResiliencyTests extends OpenSearchTestCase {
                     random(),
                     rerouteService,
                     ElectionStrategy.DEFAULT_INSTANCE,
-                    () -> new StatusInfo(HEALTHY, "healthy-info")
+                    () -> new StatusInfo(HEALTHY, "healthy-info"),
+                    new PersistedStateRegistry()
                 );
                 clusterManagerService.setClusterStatePublisher(coordinator);
                 coordinator.start();

--- a/test/framework/src/main/java/org/opensearch/cluster/coordination/AbstractCoordinatorTestCase.java
+++ b/test/framework/src/main/java/org/opensearch/cluster/coordination/AbstractCoordinatorTestCase.java
@@ -1144,7 +1144,8 @@ public class AbstractCoordinatorTestCase extends OpenSearchTestCase {
                     Randomness.get(),
                     (s, p, r) -> {},
                     getElectionStrategy(),
-                    nodeHealthService
+                    nodeHealthService,
+                    new PersistedStateRegistry()
                 );
                 clusterManagerService.setClusterStatePublisher(coordinator);
                 final GatewayService gatewayService = new GatewayService(

--- a/test/framework/src/main/java/org/opensearch/cluster/coordination/CoordinationStateTestCluster.java
+++ b/test/framework/src/main/java/org/opensearch/cluster/coordination/CoordinationStateTestCluster.java
@@ -128,6 +128,8 @@ public class CoordinationStateTestCluster {
 
         DiscoveryNode localNode;
         CoordinationState.PersistedState persistedState;
+        CoordinationState.PersistedState remotePersistedState;
+
         CoordinationState state;
 
         ClusterNode(DiscoveryNode localNode, ElectionStrategy electionStrategy) {
@@ -143,8 +145,20 @@ public class CoordinationStateTestCluster {
                     0L
                 )
             );
+            remotePersistedState = new InMemoryPersistedState(
+                0L,
+                clusterState(
+                    0L,
+                    0L,
+                    localNode,
+                    CoordinationMetadata.VotingConfiguration.EMPTY_CONFIG,
+                    CoordinationMetadata.VotingConfiguration.EMPTY_CONFIG,
+                    0L
+                )
+            );
+
             this.electionStrategy = electionStrategy;
-            state = new CoordinationState(localNode, persistedState, electionStrategy);
+            state = new CoordinationState(localNode, persistedState, electionStrategy, remotePersistedState, Settings.EMPTY);
         }
 
         void reboot() {
@@ -183,7 +197,7 @@ public class CoordinationStateTestCluster {
                 localNode.getVersion()
             );
 
-            state = new CoordinationState(localNode, persistedState, electionStrategy);
+            state = new CoordinationState(localNode, persistedState, electionStrategy, remotePersistedState, Settings.EMPTY);
         }
 
         void setInitialState(CoordinationMetadata.VotingConfiguration initialConfig, long initialValue) {

--- a/test/framework/src/main/java/org/opensearch/gateway/MockGatewayMetaState.java
+++ b/test/framework/src/main/java/org/opensearch/gateway/MockGatewayMetaState.java
@@ -32,6 +32,7 @@
 
 package org.opensearch.gateway;
 
+import java.util.Collections;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.Manifest;
 import org.opensearch.cluster.metadata.Metadata;
@@ -44,7 +45,9 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.BigArrays;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.env.NodeEnvironment;
+import org.opensearch.gateway.remote.RemoteClusterStateService;
 import org.opensearch.plugins.MetadataUpgrader;
+import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
@@ -54,12 +57,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * {@link GatewayMetaState} constructor accepts a lot of arguments.
- * It's not always easy / convenient to construct these dependencies.
- * This class constructor takes far fewer dependencies and constructs usable {@link GatewayMetaState} with 2 restrictions:
- * no metadata upgrade will be performed and no cluster state updaters will be run. This is sufficient for most of the tests.
+ * {@link GatewayMetaState} constructor accepts a lot of arguments. It's not always easy / convenient to construct these dependencies. This class constructor
+ * takes far fewer dependencies and constructs usable {@link GatewayMetaState} with 2 restrictions: no metadata upgrade will be performed and no cluster state
+ * updaters will be run. This is sufficient for most of the tests.
  */
 public class MockGatewayMetaState extends GatewayMetaState {
+
     private final DiscoveryNode localNode;
     private final BigArrays bigArrays;
 
@@ -110,7 +113,11 @@ public class MockGatewayMetaState extends GatewayMetaState {
                 bigArrays,
                 new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
                 () -> 0L
-            )
+            ),
+            new RemoteClusterStateService(
+                () -> new RepositoriesService(settings, clusterService, transportService, Collections.emptyMap(), Collections.emptyMap(),
+                    transportService.getThreadPool()), settings, new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
+                () -> 0L)
         );
     }
 }

--- a/test/framework/src/main/java/org/opensearch/gateway/MockGatewayMetaState.java
+++ b/test/framework/src/main/java/org/opensearch/gateway/MockGatewayMetaState.java
@@ -32,7 +32,6 @@
 
 package org.opensearch.gateway;
 
-import java.util.Collections;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.Manifest;
 import org.opensearch.cluster.metadata.Metadata;
@@ -52,17 +51,18 @@ import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 
 import java.io.IOException;
+import java.util.Collections;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * {@link GatewayMetaState} constructor accepts a lot of arguments. It's not always easy / convenient to construct these dependencies. This class constructor
- * takes far fewer dependencies and constructs usable {@link GatewayMetaState} with 2 restrictions: no metadata upgrade will be performed and no cluster state
- * updaters will be run. This is sufficient for most of the tests.
+ * {@link GatewayMetaState} constructor accepts a lot of arguments.
+ * It's not always easy / convenient to construct these dependencies.
+ * This class constructor takes far fewer dependencies and constructs usable {@link GatewayMetaState} with 2 restrictions:
+ * no metadata upgrade will be performed and no cluster state updaters will be run. This is sufficient for most of the tests.
  */
 public class MockGatewayMetaState extends GatewayMetaState {
-
     private final DiscoveryNode localNode;
     private final BigArrays bigArrays;
 
@@ -115,9 +115,19 @@ public class MockGatewayMetaState extends GatewayMetaState {
                 () -> 0L
             ),
             new RemoteClusterStateService(
-                () -> new RepositoriesService(settings, clusterService, transportService, Collections.emptyMap(), Collections.emptyMap(),
-                    transportService.getThreadPool()), settings, new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
-                () -> 0L)
+                nodeEnvironment.nodeId(),
+                () -> new RepositoriesService(
+                    settings,
+                    clusterService,
+                    transportService,
+                    Collections.emptyMap(),
+                    Collections.emptyMap(),
+                    transportService.getThreadPool()
+                ),
+                settings,
+                new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
+                () -> 0L
+            )
         );
     }
 }

--- a/test/framework/src/main/java/org/opensearch/gateway/MockGatewayMetaState.java
+++ b/test/framework/src/main/java/org/opensearch/gateway/MockGatewayMetaState.java
@@ -33,6 +33,7 @@
 package org.opensearch.gateway;
 
 import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.coordination.PersistedStateRegistry;
 import org.opensearch.cluster.metadata.Manifest;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.metadata.MetadataIndexUpgradeService;
@@ -127,7 +128,8 @@ public class MockGatewayMetaState extends GatewayMetaState {
                 settings,
                 new ClusterSettings(settings, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
                 () -> 0L
-            )
+            ),
+            new PersistedStateRegistry()
         );
     }
 }


### PR DESCRIPTION
### Description
Follow up PR for : https://github.com/opensearch-project/OpenSearch/pull/9160
In the above PR, RemotePersistedState and RemoteClusterStateService were created. In the current PR, these classes are integrated into the cluster state publish flow. The upload of cluster metadata will happen just before the cluster state publish request is sent to all nodes

### Related Issues
https://github.com/opensearch-project/OpenSearch/issues/9338

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff
- [ ] Commit changes are listed out in CHANGELOG.md file (See: [Changelog](../blob/main/CONTRIBUTING.md#changelog))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
